### PR TITLE
amd-power-control: COLD reset fix to move state to "off" and then "on"

### DIFF
--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -59,7 +59,7 @@ const static constexpr int powerCycleTimeMs = 5000;
 const static constexpr int psPowerOKWatchdogTimeMs = 8000;
 const static constexpr int psPowerOKRampDownTimeMs = 8000;
 const static constexpr int gracefulPowerOffTimeMs = 90000;
-const static constexpr int warmResetCheckTimeMs = 100;
+const static constexpr int warmResetCheckTimeMs = 1000;
 const static constexpr int powerOffSaveTimeMs = 7000;
 
 const static std::filesystem::path powerControlDir = "/var/lib/power-control";
@@ -350,12 +350,12 @@ static constexpr std::string_view getHostState(const PowerState state)
         case PowerState::gracefulTransitionToOff:
         case PowerState::transitionToCycleOff:
         case PowerState::gracefulTransitionToCycleOff:
-        case PowerState::checkForWarmReset:
             return "xyz.openbmc_project.State.Host.HostState.Running";
             break;
         case PowerState::waitForPSPowerOK:
         case PowerState::off:
         case PowerState::cycleOff:
+        case PowerState::checkForWarmReset:
             return "xyz.openbmc_project.State.Host.HostState.Off";
             break;
         default:


### PR DESCRIPTION
COLD reset fix to move state to "off" and then "on".
Reset Button event does not generate PWR OK line events. This is
simulated by setting the host state to "off" when reset button press is
detected and host state will be manually set to "on" after 1 second
timer expires.

Cold reset timer is cahnged from 100 ms to 1 second.

Signed-off-by: Supreeth Venkatesh <supreeth.venkatesh@amd.com>