### PR TITLE
amd-power-control: start after dimm info service

### DIFF
--- a/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
+++ b/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Amd Power Control
+Wants=mapper-wait@-xyz-openbmc_project-inventory.service
+After=dimm-info.service
 
 [Service]
 Restart=always


### PR DESCRIPTION
dimm-info.service waits for Inventory service
amd power control service will wait for DIMM info service
to make sure DIMM SPD data is collected before processing the power
requests

Signed-off-by: Mohsen Dolaty <mohsen.dolaty@amd.com>