### PR TITLE
amd-power-control:Call DIMM SPD Info script

### DIFF
--- a/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
+++ b/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Amd Power Control
 Wants=mapper-wait@-xyz-openbmc_project-inventory.service
-After=dimm-info.service
+After=mapper-wait@-xyz-openbmc_project-inventory.service
 
 [Service]
 Restart=always

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -1487,6 +1487,8 @@ int main(int argc, char* argv[])
 {
     std::cerr << "Start Chassis power control service...\n";
 
+    if (system("/usr/sbin/dimm-info.sh") != 0)
+        std::cerr << "Error calling dimm-info.sh in Chassis power control service \n";
     power_control::conn =
         std::make_shared<sdbusplus::asio::connection>(power_control::io);
 
@@ -1522,8 +1524,6 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    // Check if we need to start the Power Restore policy
-    power_control::powerRestorePolicyCheck();
     power_control::nmiSourcePropertyMonitor();
 
     std::cerr << "Initializing power state. ";
@@ -1810,6 +1810,9 @@ int main(int argc, char* argv[])
     {
         return -1;
     }
+
+    // Check if we need to start the Power Restore policy
+    power_control::powerRestorePolicyCheck();
 
     power_control::io.run();
 


### PR DESCRIPTION
Call dimm-info.sh from the main() function
to collect DIMM SPD data
Move PowerRestorePolicyCheck() to the end of main() because of timing issues

Signed-off-by: Mohsen Dolaty <mohsen.dolaty@amd.com>