### PR TITLE
Review

### DIFF
--- a/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
+++ b/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Amd Power Control
+Wants=mapper-wait@-xyz-openbmc_project-inventory.service
+After=dimm-info.service
 
 [Service]
 Restart=always

--- a/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
+++ b/power-control-x86/service_files/xyz.openbmc_project.Chassis.Control.Power.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Amd Power Control
 Wants=mapper-wait@-xyz-openbmc_project-inventory.service
-After=dimm-info.service
+After=mapper-wait@-xyz-openbmc_project-inventory.service
 
 [Service]
 Restart=always

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -34,6 +34,10 @@
 #include <iostream>
 #include <string_view>
 
+#include <thread>
+#define CHASSIS_INTRUDED         (0)
+#define INTRUSION_POLL_INTERVAL  (1)
+
 namespace power_control
 {
 static boost::asio::io_service io;
@@ -1390,6 +1394,57 @@ void systemReset()
         systemdBusname, systemdPath, systemdInterface, "StartUnit",
         systemTargetName, "replace");
 }
+static void chassisIntrusionMonitor()
+{
+    /* AST2500/2600 chass intrusion controller dev path */
+    const std::string driver_path = "/sys/devices/platform/ahb/ahb:apb/1e6ef010.chassis/hwmon/";
+    const std::string hwmon_filename = "/intrusion0_alarm";
+    std::string hwmon_folder;
+
+    /* we don't know hwmon folder's number in path, search platform.
+       driver creates only one hwmon folder, break on first result */
+    if (std::filesystem::exists (driver_path))
+    {
+        for (const auto& folder : std::filesystem::directory_iterator(driver_path))
+        {
+            hwmon_folder = folder.path();
+            break;
+        }
+
+        /* check for intrusion sysfs file, 0 -> assert, 1 -> deassert */
+        if (std::filesystem::exists (hwmon_folder + hwmon_filename))
+        {
+            /* create polling thread, interval 1 sec (phosphor-hwmon default interval) */
+            std::thread([hwmon_folder, hwmon_filename](){
+                std::ifstream hfile;
+                unsigned int alarm_status;
+                unsigned int prev_status = 0xFF;
+                while(1) {
+                    std::this_thread::sleep_for(std::chrono::seconds(INTRUSION_POLL_INTERVAL));
+                    hfile.open(hwmon_folder + hwmon_filename);
+                    hfile >> alarm_status;
+                    hfile.close();
+                    if(prev_status != alarm_status)
+                    {
+                        prev_status = alarm_status;
+                        if(alarm_status == CHASSIS_INTRUDED)
+                        {
+                            sd_journal_send("MESSAGE=Chassis Intrusion Detected. Current state: Open",
+                                    "PRIORITY=%i", LOG_WARNING, "REDFISH_MESSAGE_ID=%s",
+                                    "OpenBMC.0.1.ChassisIntrusionDetected", NULL);
+                        }
+                        else
+                        {
+                            sd_journal_send("MESSAGE=Chassis Intrusion Recovered. Current state: Closed",
+                                    "PRIORITY=%i", LOG_INFO, "REDFISH_MESSAGE_ID=%s",
+                                    "OpenBMC.0.1.ChassisIntrusionReset", NULL);
+                        }
+                    }
+                }
+            }).detach();
+        }
+    }
+}
 
 static void nmiSetEnableProperty(bool value)
 {
@@ -1524,6 +1579,7 @@ int main(int argc, char* argv[])
         return -1;
     }
 
+    power_control::chassisIntrusionMonitor();
     power_control::nmiSourcePropertyMonitor();
 
     std::cerr << "Initializing power state. ";

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -1487,6 +1487,8 @@ int main(int argc, char* argv[])
 {
     std::cerr << "Start Chassis power control service...\n";
 
+    if (system("/usr/sbin/dimm-info.sh") != 0)
+        std::cerr << "Error calling dimm-info.sh in Chassis power control service \n";
     power_control::conn =
         std::make_shared<sdbusplus::asio::connection>(power_control::io);
 
@@ -1522,8 +1524,6 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    // Check if we need to start the Power Restore policy
-    power_control::powerRestorePolicyCheck();
     power_control::nmiSourcePropertyMonitor();
 
     std::cerr << "Initializing power state. ";
@@ -1810,6 +1810,9 @@ int main(int argc, char* argv[])
     {
         return -1;
     }
+
+    // Check if we need to start the Power Restore policy
+    power_control::powerRestorePolicyCheck();
 
     power_control::io.run();
 

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -59,7 +59,7 @@ const static constexpr int powerCycleTimeMs = 5000;
 const static constexpr int psPowerOKWatchdogTimeMs = 8000;
 const static constexpr int psPowerOKRampDownTimeMs = 8000;
 const static constexpr int gracefulPowerOffTimeMs = 90000;
-const static constexpr int warmResetCheckTimeMs = 100;
+const static constexpr int warmResetCheckTimeMs = 1000;
 const static constexpr int powerOffSaveTimeMs = 7000;
 
 const static std::filesystem::path powerControlDir = "/var/lib/power-control";
@@ -350,12 +350,12 @@ static constexpr std::string_view getHostState(const PowerState state)
         case PowerState::gracefulTransitionToOff:
         case PowerState::transitionToCycleOff:
         case PowerState::gracefulTransitionToCycleOff:
-        case PowerState::checkForWarmReset:
             return "xyz.openbmc_project.State.Host.HostState.Running";
             break;
         case PowerState::waitForPSPowerOK:
         case PowerState::off:
         case PowerState::cycleOff:
+        case PowerState::checkForWarmReset:
             return "xyz.openbmc_project.State.Host.HostState.Off";
             break;
         default:

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -34,10 +34,6 @@
 #include <iostream>
 #include <string_view>
 
-#include <thread>
-#define CHASSIS_INTRUDED         (0)
-#define INTRUSION_POLL_INTERVAL  (1)
-
 namespace power_control
 {
 static boost::asio::io_service io;
@@ -1394,57 +1390,6 @@ void systemReset()
         systemdBusname, systemdPath, systemdInterface, "StartUnit",
         systemTargetName, "replace");
 }
-static void chassisIntrusionMonitor()
-{
-    /* AST2500/2600 chass intrusion controller dev path */
-    const std::string driver_path = "/sys/devices/platform/ahb/ahb:apb/1e6ef010.chassis/hwmon/";
-    const std::string hwmon_filename = "/intrusion0_alarm";
-    std::string hwmon_folder;
-
-    /* we don't know hwmon folder's number in path, search platform.
-       driver creates only one hwmon folder, break on first result */
-    if (std::filesystem::exists (driver_path))
-    {
-        for (const auto& folder : std::filesystem::directory_iterator(driver_path))
-        {
-            hwmon_folder = folder.path();
-            break;
-        }
-
-        /* check for intrusion sysfs file, 0 -> assert, 1 -> deassert */
-        if (std::filesystem::exists (hwmon_folder + hwmon_filename))
-        {
-            /* create polling thread, interval 1 sec (phosphor-hwmon default interval) */
-            std::thread([hwmon_folder, hwmon_filename](){
-                std::ifstream hfile;
-                unsigned int alarm_status;
-                unsigned int prev_status = 0xFF;
-                while(1) {
-                    std::this_thread::sleep_for(std::chrono::seconds(INTRUSION_POLL_INTERVAL));
-                    hfile.open(hwmon_folder + hwmon_filename);
-                    hfile >> alarm_status;
-                    hfile.close();
-                    if(prev_status != alarm_status)
-                    {
-                        prev_status = alarm_status;
-                        if(alarm_status == CHASSIS_INTRUDED)
-                        {
-                            sd_journal_send("MESSAGE=Chassis Intrusion Detected. Current state: Open",
-                                    "PRIORITY=%i", LOG_WARNING, "REDFISH_MESSAGE_ID=%s",
-                                    "OpenBMC.0.1.ChassisIntrusionDetected", NULL);
-                        }
-                        else
-                        {
-                            sd_journal_send("MESSAGE=Chassis Intrusion Recovered. Current state: Closed",
-                                    "PRIORITY=%i", LOG_INFO, "REDFISH_MESSAGE_ID=%s",
-                                    "OpenBMC.0.1.ChassisIntrusionReset", NULL);
-                        }
-                    }
-                }
-            }).detach();
-        }
-    }
-}
 
 static void nmiSetEnableProperty(bool value)
 {
@@ -1579,7 +1524,6 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    power_control::chassisIntrusionMonitor();
     power_control::nmiSourcePropertyMonitor();
 
     std::cerr << "Initializing power state. ";

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -34,6 +34,38 @@
 #include <iostream>
 #include <string_view>
 
+constexpr auto ONYX_SLT     = 61;   //0x3D
+constexpr auto ONYX_1       = 64;   //0x40
+constexpr auto ONYX_2       = 65;   //0x41
+constexpr auto ONYX_3       = 66;   //0x42
+constexpr auto ONYX_FR4     = 82;   //0x52
+constexpr auto QUARTZ_DAP   = 62;   //0x3E
+constexpr auto QUARTZ_1     = 67;   //0x43
+constexpr auto QUARTZ_2     = 68;   //0x44
+constexpr auto QUARTZ_3     = 69;   //0x45
+constexpr auto QUARTZ_FR4   = 81;   //0x51
+constexpr auto RUBY_1       = 70;   //0x46
+constexpr auto RUBY_2       = 71;   //0x47
+constexpr auto RUBY_3       = 72;   //0x48
+constexpr auto TITANITE_1   = 73;   //0x49
+constexpr auto TITANITE_2   = 74;   //0x4A
+constexpr auto TITANITE_3   = 75;   //0x4B
+constexpr auto TITANITE_4   = 76;   //0x4C
+constexpr auto TITANITE_5   = 77;   //0x4D
+constexpr auto TITANITE_6   = 78;   //0x4E
+
+#define COMMAND_BOARD_ID    ("/sbin/fw_printenv -n board_id")
+#define COMMAND_OUTPUT_LEN  (8)
+
+/* Definition for APML Mux setting */
+#define I2C_MUX         0x70
+#define I2C_MUX_MR46    0x46
+#define I2C_MUX_MR64    0x40  // MUX port sel
+#define I2C_MUX_MR65    0x41  // MUX port rw enable
+#define CMD_BUFF_LEN    64
+#define BDID_BUFF_LEN   8
+
+
 namespace power_control
 {
 static boost::asio::io_service io;
@@ -102,6 +134,81 @@ enum class PowerState
     gracefulTransitionToCycleOff,
     checkForWarmReset,
 };
+
+/* Read platform ID from env */
+static bool getPlatformID(char *data)
+{
+    FILE *pf;
+    // Setup pipe for reading and execute to get u-boot environment variable board_id.
+    pf = popen(COMMAND_BOARD_ID,"r");
+    if(pf < 0)
+    {
+        std::cerr << "Unable to read Board ID from env" << "\n";
+        return false;
+    }
+    // Get the data from the process execution
+    if (fgets(data, COMMAND_OUTPUT_LEN , pf) == NULL)
+    {
+        std::cerr << "Board ID is not set in env" << "\n";
+        return false;
+    }
+    // the data is now in 'data'
+    if (pclose(pf) != 0)
+    {
+        std::cerr << "Failed to close command stream" << "\n";
+        return false;
+    }
+    return true;
+}
+
+static void resetAPMLMuxChannel()
+{
+    char cmd[CMD_BUFF_LEN];
+    char data[BDID_BUFF_LEN];
+    unsigned int board_id;
+    std::stringstream ss;
+    int num_of_apml_bus=2;  /* Default num of bus = 2 */
+    int apml_bus=2;         /* start with APML bus 2 */
+
+    /* Code for APML bus Mux settings */
+    if (power_control::psPowerOKLine.get_value() > 0)
+    {
+        if (getPlatformID(data))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> board_id;
+            switch (board_id)
+            {
+                case ONYX_SLT:
+                case ONYX_FR4:
+                case ONYX_1 ... ONYX_3:
+                case RUBY_1 ... RUBY_3:
+                    /* For Onyx and Ruby 1P systems */
+                    num_of_apml_bus = 1;
+                    break;
+                default:
+                    /* For Quartz and Titanite 2P systems */
+                    num_of_apml_bus = 2;
+                    break;
+            }//switch
+        }
+        for  ( int i=0; i<num_of_apml_bus; i++)
+        {
+            std::cout << "Setting APML Mux registers on i2c bus " << apml_bus << std::endl;
+            sprintf(cmd, "i2cset -f -y %d 0x%02x 0x%02x 0x01 >& /dev/null\n", apml_bus, I2C_MUX, I2C_MUX_MR46);
+            if (system(cmd) != 0)
+                std::cout <<"Failed to set APML MUX on bus " << apml_bus << " reg 0x" << I2C_MUX_MR46 << " OR no CPU installed" << "\n";
+            sprintf(cmd, "i2cset -f -y %d 0x%02x 0x%02x 0x40 >& /dev/null\n", apml_bus, I2C_MUX, I2C_MUX_MR64);
+            if (system(cmd) != 0)
+                std::cout <<"Failed to set APML MUX on bus " << apml_bus << " reg 0x" << I2C_MUX_MR64 << " OR no CPU installed" << "\n";
+            sprintf(cmd, "i2cset -f -y %d 0x%02x 0x%02x 0x40 >& /dev/null\n", apml_bus, I2C_MUX, I2C_MUX_MR65);
+            if (system(cmd) != 0)
+                std::cout <<"Failed to set APML MUX on bus " << apml_bus << " reg 0x" << I2C_MUX_MR65<< " OR no CPU installed" << "\n";
+            apml_bus++;
+        }
+    }
+    return;
+}
 
 static int getGPIOValue(const std::string& name)
 {
@@ -1249,6 +1356,10 @@ static void psPowerOKHandler()
             : Event::psPowerOKDeAssert;
 
     sendPowerControlEvent(powerControlEvent);
+
+    /* Reset the APML Mux channel with each power on event */
+    resetAPMLMuxChannel();
+
     psPowerOKEvent.async_wait(
         boost::asio::posix::stream_descriptor::wait_read,
         [](const boost::system::error_code ec) {

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -784,16 +784,20 @@ static int setGPIOOutputForMs(const std::string& name, const int value,
 static void powerOn()
 {
     setGPIOOutputForMs("ASSERT_PWR_BTN_L", 0, powerPulseTimeMs);
+    system("systemctl enable yaapd.service");
+    system("systemctl start yaapd.service");
 }
 
 static void gracefulPowerOff()
 {
     setGPIOOutputForMs("ASSERT_PWR_BTN_L", 0, powerPulseTimeMs);
+    system("systemctl stop yaapd.service");
 }
 
 static void forcePowerOff()
 {
     setGPIOOutputForMs("ASSERT_PWR_BTN_L", 0, forceOffPulseTimeMs);
+    system("systemctl stop yaapd.service");
     return;
 }
 

--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -614,6 +614,7 @@ static void powerRestorePolicyCheck()
                 const std::variant<std::string>& restorepolicy) {
         if (ec)
         {
+            std::cerr << "Error read restore policy\n";
             return;
         }
         const std::string* policy =
@@ -630,18 +631,18 @@ static void powerRestorePolicyCheck()
         }
         else
         {
-            std::cerr << "Invoking Restore Policy: " << policy << "\n";
+            std::cerr << "Invoking Restore Policy: " << policy->c_str() << " \n";
 
             sd_journal_send("MESSAGE=PowerControl: power restore policy applied",
                     "PRIORITY=%i", LOG_INFO, "REDFISH_MESSAGE_ID=%s",
                     "OpenBMC.0.1.PowerRestorePolicyApplied", NULL);
 
-            if (policy->compare("AlwaysOn") == 0)
+            if (policy->compare("xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOn") == 0)
             {
                 sendPowerControlEvent(Event::powerOnRequest);
                 setRestartCauseProperty(getRestartCause(RestartCause::powerPolicyOn));
             }
-            else if (policy->compare("Policy.Restore") == 0)
+            else if (policy->compare("xyz.openbmc_project.Control.Power.RestorePolicy.Policy.Restore") == 0)
             {
                 if (wasPowerDropped())
                 {
@@ -1517,6 +1518,7 @@ int main(int argc, char* argv[])
     // Initialize the power state storage
     if (power_control::initializePowerStateStorage() < 0)
     {
+        std::cerr << "initializePowerStateStorage return Error ";
         return -1;
     }
 


### PR DESCRIPTION
In this implementation, if host is powered on too early, yaap fails to get CPU ID code. But with subsequent power off and power on, yaap works correctly. So yaap process can be started and stopped along with host. 