### PR TITLE
amd-power-control: Enable YAAP service

### DIFF
--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -1927,6 +1927,10 @@ int main(int argc, char* argv[])
     {
         return -1;
     }
+    else
+    {
+        system("systemctl start yaapd.service");
+    }
 
     // Check if we need to start the Power Restore policy
     power_control::powerRestorePolicyCheck();


### PR DESCRIPTION
Start YAAP service once BMC ready signal is received.